### PR TITLE
Add UI entry point for company dashboard access

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import Practice from "@/pages/practice";
 import Prepare from "@/pages/prepare";
 import Perform from "@/pages/perform";
 import AdminDashboard from "@/pages/admin/dashboard";
+import CompanyDashboard from "@/pages/company/dashboard";
 import AuthenticatedLanding from "@/components/AuthenticatedLanding";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import { useAuth } from "@/hooks/use-auth";
@@ -30,6 +31,11 @@ function Router() {
       <Route path="/practice/*" component={Practice} />
       <Route path="/perform" component={Perform} />
       <Route path="/perform/*" component={Perform} />
+      <Route path="/company">
+        <ProtectedRoute>
+          <CompanyDashboard />
+        </ProtectedRoute>
+      </Route>
       {user?.role === 'admin' && (
         <Route path="/admin/*" component={AdminDashboard} />
       )}

--- a/client/src/components/AuthenticatedLanding.tsx
+++ b/client/src/components/AuthenticatedLanding.tsx
@@ -5,17 +5,19 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { SeaLionLogo } from "@/components/ui/sealion-logo";
 import { 
-  BookOpen, 
-  Target, 
-  Award, 
-  ArrowRight, 
-  TrendingUp, 
-  Clock, 
+  BookOpen,
+  Target,
+  Award,
+  ArrowRight,
+  TrendingUp,
+  Clock,
   LogOut,
   User,
   BarChart3,
   Play,
-  Settings
+  Settings,
+  Building2,
+  ShieldCheck
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
@@ -26,6 +28,7 @@ interface AuthenticatedLandingProps {
 }
 
 export default function AuthenticatedLanding({ user }: AuthenticatedLandingProps) {
+  const showCompanyDashboard = user.role === 'admin' || user.role === 'manager';
   // Fetch user's recent activity and progress (with error handling)
   const { data: dashboard, isError } = useQuery({
     queryKey: ["/api/perform/dashboard"],
@@ -91,6 +94,14 @@ export default function AuthenticatedLanding({ user }: AuthenticatedLandingProps
                   Perform
                 </Button>
               </Link>
+              {showCompanyDashboard && (
+                <Link href="/company">
+                  <Button variant="ghost" size="sm">
+                    <Building2 className="w-4 h-4 mr-2" />
+                    Company
+                  </Button>
+                </Link>
+              )}
               <div className="flex items-center space-x-3 pl-4 border-l border-gray-200">
                 <Avatar className="w-8 h-8">
                   <AvatarImage src={user.profileImageUrl || undefined} />
@@ -201,7 +212,7 @@ export default function AuthenticatedLanding({ user }: AuthenticatedLandingProps
           )}
 
           {/* Module Cards */}
-          <div className="grid lg:grid-cols-3 gap-8 mb-8">
+          <div className={`grid gap-8 mb-8 ${showCompanyDashboard ? 'lg:grid-cols-4' : 'lg:grid-cols-3'}`}>
             <Card className="relative border-0 shadow-lg hover:shadow-xl transition-all duration-300 group">
               <CardHeader className="pb-4">
                 <div className="flex items-center justify-between mb-4">
@@ -226,6 +237,34 @@ export default function AuthenticatedLanding({ user }: AuthenticatedLandingProps
                 </Link>
               </CardContent>
             </Card>
+
+            {showCompanyDashboard && (
+              <Card className="relative border-0 shadow-lg hover:shadow-xl transition-all duration-300 group">
+                <CardHeader className="pb-4">
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="w-12 h-12 bg-slate-500 bg-opacity-10 rounded-lg flex items-center justify-center">
+                      <Building2 className="w-6 h-6 text-slate-600" />
+                    </div>
+                    <Badge className="bg-slate-100 text-slate-800">
+                      Admin
+                    </Badge>
+                  </div>
+                  <CardTitle className="text-xl font-bold text-gray-900">Company</CardTitle>
+                  <CardDescription className="text-gray-600">
+                    Provision team accounts, allocate credits, and review usage directly from the company dashboard.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Link href="/company">
+                    <Button className="w-full group-hover:scale-105 transition-transform bg-slate-900 hover:bg-slate-800">
+                      <ShieldCheck className="mr-2 w-4 h-4" />
+                      Open company dashboard
+                      <ArrowRight className="ml-2 w-4 h-4" />
+                    </Button>
+                  </Link>
+                </CardContent>
+              </Card>
+            )}
 
             <Card className="relative border-0 shadow-lg hover:shadow-xl transition-all duration-300 group">
               <CardHeader className="pb-4">

--- a/client/src/pages/company/dashboard.tsx
+++ b/client/src/pages/company/dashboard.tsx
@@ -1,0 +1,537 @@
+import { useMemo } from "react";
+import { Link } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useAuth } from "@/hooks/use-auth";
+import { apiRequest } from "@/lib/queryClient";
+import type {
+  CreditLedgerSnapshot,
+  UsageEventSnapshot,
+  UserCreditSummary,
+} from "@shared/types";
+import {
+  Activity,
+  AlertCircle,
+  ArrowLeft,
+  Building2,
+  CalendarCheck,
+  Coins,
+  History,
+  RefreshCw,
+  ShieldCheck,
+  Users2,
+} from "lucide-react";
+
+type SerializedLedgerEntry = Omit<CreditLedgerSnapshot, "createdAt"> & {
+  createdAt: string;
+};
+
+type SerializedUsageEvent = Omit<UsageEventSnapshot, "occurredAt"> & {
+  occurredAt: string;
+};
+
+type SerializedUserCreditSummary = Omit<
+  UserCreditSummary,
+  "billingCycleStart" | "billingCycleEnd" | "recentLedger" | "recentUsageEvents"
+> & {
+  billingCycleStart: string | null;
+  billingCycleEnd: string | null;
+  recentLedger: SerializedLedgerEntry[];
+  recentUsageEvents: SerializedUsageEvent[];
+};
+
+interface CreditSummaryResponse {
+  success: boolean;
+  data: SerializedUserCreditSummary;
+}
+
+function deserializeCreditSummary(
+  payload: SerializedUserCreditSummary,
+): UserCreditSummary {
+  const {
+    billingCycleStart,
+    billingCycleEnd,
+    recentLedger,
+    recentUsageEvents,
+    ...rest
+  } = payload;
+
+  return {
+    ...rest,
+    billingCycleStart: billingCycleStart ? new Date(billingCycleStart) : null,
+    billingCycleEnd: billingCycleEnd ? new Date(billingCycleEnd) : null,
+    recentLedger: recentLedger.map((entry) => ({
+      ...entry,
+      createdAt: new Date(entry.createdAt),
+    })),
+    recentUsageEvents: recentUsageEvents.map((event) => ({
+      ...event,
+      occurredAt: new Date(event.occurredAt),
+    })),
+  };
+}
+
+function formatDateTime(value: Date | null, fallback = "Not set") {
+  if (!value) {
+    return fallback;
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(value);
+}
+
+const COMPANY_ROLES = new Set(["admin", "manager"]);
+
+export default function CompanyDashboard() {
+  const { user } = useAuth();
+  const canAccessCompanyTools = useMemo(
+    () => (user?.role ? COMPANY_ROLES.has(user.role) : false),
+    [user?.role],
+  );
+
+  const {
+    data: summary,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<UserCreditSummary>({
+    queryKey: ["/api/company/credits/me"],
+    enabled: canAccessCompanyTools,
+    queryFn: async () => {
+      const response = await apiRequest("GET", "/api/company/credits/me");
+      const json = (await response.json()) as CreditSummaryResponse;
+
+      if (!json.success) {
+        throw new Error("Unable to load credit summary");
+      }
+
+      return deserializeCreditSummary(json.data);
+    },
+  });
+
+  if (!user) {
+    return null;
+  }
+
+  if (!canAccessCompanyTools) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-6">
+        <Card className="w-full max-w-lg">
+          <CardHeader>
+            <div className="w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center mb-4">
+              <AlertCircle className="w-6 h-6 text-amber-600" />
+            </div>
+            <CardTitle>Company dashboard restricted</CardTitle>
+            <CardDescription>
+              Only company administrators or organization managers can view this
+              area.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-gray-600">
+              Please contact your company administrator if you believe you
+              should have access to provisioning tools and usage insights.
+            </p>
+            <Button variant="outline" className="w-full" asChild>
+              <Link href="/dashboard">
+                <ArrowLeft className="mr-2 w-4 h-4" />
+                Back to dashboard
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const tierLabel = summary?.accountTier === "paid" ? "Paid" : "Free";
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="bg-white border-b border-slate-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 py-6 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-lg bg-slate-900 text-white flex items-center justify-center">
+                  <Building2 className="w-5 h-5" />
+                </div>
+                <div>
+                  <p className="text-sm text-slate-500">Company workspace</p>
+                  <h1 className="text-2xl font-semibold text-slate-900">
+                    Company dashboard
+                  </h1>
+                </div>
+              </div>
+              <p className="mt-4 max-w-2xl text-sm text-slate-600">
+                You can reach this space by signing in through the standard
+                login page and using the new <strong>Company</strong> link in
+                the top navigation. From here you can monitor credit balances,
+                track usage, and provision members.
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <Badge variant="secondary" className="text-slate-700">
+                {tierLabel} tier
+              </Badge>
+              <Button variant="outline" onClick={() => refetch()} disabled={isLoading}>
+                <RefreshCw
+                  className={`mr-2 h-4 w-4 ${isLoading ? "animate-spin" : ""}`}
+                />
+                Refresh
+              </Button>
+              <Button variant="ghost" asChild>
+                <Link href="/dashboard">
+                  <ArrowLeft className="mr-2 h-4 w-4" />
+                  Main dashboard
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
+        {isLoading && (
+          <Card>
+            <CardContent className="flex items-center justify-center py-12">
+              <div className="flex items-center gap-3 text-slate-600">
+                <RefreshCw className="h-5 w-5 animate-spin" />
+                <span>Loading company credits…</span>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {isError && (
+          <Card className="border-red-200 bg-red-50">
+            <CardHeader>
+              <CardTitle className="text-red-900 flex items-center gap-2">
+                <AlertCircle className="h-5 w-5" />
+                Unable to load credit summary
+              </CardTitle>
+              <CardDescription className="text-red-800">
+                {(error as Error)?.message ?? "Please try again."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button onClick={() => refetch()} variant="outline">
+                Retry
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {summary && !isLoading && !isError && (
+          <>
+            <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium text-slate-600 flex items-center gap-2">
+                    <Coins className="h-4 w-4 text-amber-500" />
+                    Current balance
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-3xl font-semibold text-slate-900">
+                    {summary.creditBalance.toLocaleString()} credits
+                  </p>
+                  <p className="text-sm text-slate-500 mt-2">
+                    {summary.totalCreditsConsumed.toLocaleString()} consumed this
+                    cycle
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium text-slate-600 flex items-center gap-2">
+                    <Activity className="h-4 w-4 text-sky-500" />
+                    Monthly allocation
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-3xl font-semibold text-slate-900">
+                    {summary.monthlyCreditAllocation.toLocaleString()} credits
+                  </p>
+                  <p className="text-sm text-slate-500 mt-2">
+                    Allocated based on the active plan tier
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium text-slate-600 flex items-center gap-2">
+                    <CalendarCheck className="h-4 w-4 text-emerald-500" />
+                    Billing cycle
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm text-slate-600">
+                  <div>
+                    <span className="font-medium text-slate-800">Start:</span>
+                    <span className="ml-2">
+                      {formatDateTime(summary.billingCycleStart)}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="font-medium text-slate-800">Ends:</span>
+                    <span className="ml-2">
+                      {formatDateTime(summary.billingCycleEnd)}
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium text-slate-600 flex items-center gap-2">
+                    <Users2 className="h-4 w-4 text-purple-500" />
+                    Team access
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="text-sm text-slate-600 space-y-2">
+                  <p>
+                    Share this dashboard with fellow administrators or managers
+                    by assigning them the relevant role when provisioning a
+                    user.
+                  </p>
+                  <p className="text-slate-500">
+                    Organization managers can review credits for members of the
+                    teams they oversee.
+                  </p>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-slate-800">
+                    <History className="h-5 w-5 text-slate-500" />
+                    Recent credit ledger
+                  </CardTitle>
+                  <CardDescription>
+                    The most recent adjustments, refills, and consumptions
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {summary.recentLedger.length === 0 ? (
+                    <p className="text-sm text-slate-500">
+                      No ledger entries yet. Credits will appear here as soon as
+                      users start using the Prepare or Practice modules.
+                    </p>
+                  ) : (
+                    <div className="space-y-4">
+                      {summary.recentLedger.map((entry) => (
+                        <div
+                          key={entry.id}
+                          className="border border-slate-200 rounded-lg p-4 bg-white"
+                        >
+                          <div className="flex items-start justify-between">
+                            <div>
+                              <p className="font-medium text-slate-900">
+                                {entry.reason || "Credit update"}
+                              </p>
+                              <p className="text-xs text-slate-500 mt-1">
+                                {formatDateTime(entry.createdAt)}
+                              </p>
+                            </div>
+                            <div className="text-right">
+                              <p
+                                className={`text-lg font-semibold ${
+                                  entry.amount < 0
+                                    ? "text-rose-600"
+                                    : "text-emerald-600"
+                                }`}
+                              >
+                                {entry.amount > 0 ? "+" : ""}
+                                {entry.amount}
+                              </p>
+                              {entry.balanceAfter !== null && (
+                                <p className="text-xs text-slate-500">
+                                  Balance: {entry.balanceAfter}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                          <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
+                            {entry.module && (
+                              <span className="px-2 py-1 bg-slate-100 rounded-full">
+                                Module: {entry.module}
+                              </span>
+                            )}
+                            {entry.sessionId && (
+                              <span className="px-2 py-1 bg-slate-100 rounded-full">
+                                Session: {entry.sessionId}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-slate-800">
+                    <Activity className="h-5 w-5 text-slate-500" />
+                    Module breakdown
+                  </CardTitle>
+                  <CardDescription>
+                    Credits consumed by module across this billing cycle
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {summary.breakdown.length === 0 ? (
+                    <p className="text-sm text-slate-500">
+                      No usage recorded yet. Launch a Prepare or Practice session
+                      to see credit consumption here.
+                    </p>
+                  ) : (
+                    <div className="space-y-4">
+                      {summary.breakdown.map((item) => (
+                        <div
+                          key={item.module}
+                          className="flex items-center justify-between p-4 border border-slate-200 rounded-lg bg-white"
+                        >
+                          <div>
+                            <p className="font-medium text-slate-900 capitalize">
+                              {item.module}
+                            </p>
+                            <p className="text-xs text-slate-500 mt-1">
+                              {item.sessionCount} session{item.sessionCount === 1 ? "" : "s"}
+                            </p>
+                          </div>
+                          <Badge variant="outline" className="text-slate-700">
+                            {item.creditsConsumed} credits
+                          </Badge>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </section>
+
+            <section className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-slate-800">
+                    <ShieldCheck className="h-5 w-5 text-slate-500" />
+                    Administrator quick actions
+                  </CardTitle>
+                  <CardDescription>
+                    Use the dashboard APIs to provision accounts, assign roles,
+                    and update credit balances.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-slate-600">
+                  <div className="rounded-lg border border-slate-200 bg-white p-4">
+                    <p className="font-semibold text-slate-900 mb-1">
+                      Provision or update an account
+                    </p>
+                    <p>
+                      Send a <code className="px-1 py-0.5 bg-slate-100 rounded">
+                        POST /api/company/users
+                      </code>{" "}
+                      request with the user details, tier, and monthly credits.
+                      If an email already exists it will update their plan and
+                      reset the billing cycle.
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-slate-200 bg-white p-4">
+                    <p className="font-semibold text-slate-900 mb-1">
+                      Adjust credits later
+                    </p>
+                    <p>
+                      Issue a <code className="px-1 py-0.5 bg-slate-100 rounded">
+                        PATCH /api/company/users/:userId/credits
+                      </code>{" "}
+                      call to change a user&rsquo;s tier, monthly allocation, or live
+                      balance. All adjustments are recorded in the credit
+                      ledger.
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-slate-200 bg-white p-4">
+                    <p className="font-semibold text-slate-900 mb-1">
+                      Monitor organizations
+                    </p>
+                    <p>
+                      Use <code className="px-1 py-0.5 bg-slate-100 rounded">
+                        GET /api/company/organizations/:orgId/usage
+                      </code>{" "}
+                      to view every member&rsquo;s balance and session history for the
+                      teams you oversee.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-slate-800">
+                    <History className="h-5 w-5 text-slate-500" />
+                    Recent usage events
+                  </CardTitle>
+                  <CardDescription>
+                    Session-level deductions captured when credits are consumed
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {summary.recentUsageEvents.length === 0 ? (
+                    <p className="text-sm text-slate-500">
+                      No usage yet. When a Prepare or Practice session starts the
+                      consumption event will be displayed here.
+                    </p>
+                  ) : (
+                    <div className="space-y-4">
+                      {summary.recentUsageEvents.map((event) => (
+                        <div
+                          key={event.id}
+                          className="border border-slate-200 rounded-lg p-4 bg-white"
+                        >
+                          <div className="flex items-start justify-between">
+                            <div>
+                              <p className="font-medium text-slate-900 capitalize">
+                                {event.module}
+                              </p>
+                              <p className="text-xs text-slate-500 mt-1">
+                                {formatDateTime(event.occurredAt)}
+                              </p>
+                            </div>
+                            <p className="text-lg font-semibold text-rose-600">
+                              -{event.creditsConsumed}
+                            </p>
+                          </div>
+                          {event.sessionId && (
+                            <p className="text-xs text-slate-500 mt-3">
+                              Session reference: {event.sessionId}
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </section>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/server/__tests__/company-dashboard.routes.test.ts
+++ b/server/__tests__/company-dashboard.routes.test.ts
@@ -1,0 +1,204 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageMocks = vi.hoisted(() => ({
+  createOrganization: vi.fn(),
+  addOrganizationMembership: vi.fn(),
+  getOrganizationMembership: vi.fn(),
+  getOrganizationMembers: vi.fn(),
+  getOrganization: vi.fn(),
+  getUserByEmail: vi.fn(),
+  upsertUser: vi.fn(),
+  updateUser: vi.fn(),
+}));
+
+const creditServiceMocks = vi.hoisted(() => ({
+  getUserSummary: vi.fn(),
+  initializeUserAccount: vi.fn(),
+  consumeCredits: vi.fn(),
+  adminAdjustUserCredits: vi.fn(),
+}));
+
+const bcryptMock = vi.hoisted(() => ({ hash: vi.fn().mockResolvedValue("hashed-password") }));
+
+vi.mock("../storage.js", () => ({
+  storage: storageMocks,
+}));
+
+vi.mock("../services/credit-service.js", () => ({
+  creditService: creditServiceMocks,
+}));
+
+vi.mock("bcryptjs", () => ({
+  default: bcryptMock,
+  hash: bcryptMock.hash,
+}));
+
+describe("company dashboard routes", () => {
+  beforeEach(async () => {
+    Object.values(storageMocks).forEach(mockFn => mockFn.mockReset?.());
+    Object.values(creditServiceMocks).forEach(mockFn => mockFn.mockReset?.());
+    bcryptMock.hash.mockClear();
+    await vi.resetModules();
+  });
+
+  async function createApp(userOverride?: Partial<express.Request['user']>) {
+    const { default: companyDashboardRouter } = await import("../routes/company-dashboard");
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = {
+        id: "admin-1",
+        role: "admin",
+        ...userOverride,
+      } as any;
+      next();
+    });
+    app.use("/api/company", companyDashboardRouter);
+    return app;
+  }
+
+  it("returns a credit summary for the current user", async () => {
+    const app = await createApp({ id: "user-credits", role: "user" });
+
+    creditServiceMocks.getUserSummary.mockResolvedValueOnce({
+      userId: "user-credits",
+      accountTier: "free",
+      monthlyCreditAllocation: 20,
+      creditBalance: 15,
+      billingCycleStart: new Date("2025-01-01T00:00:00Z"),
+      billingCycleEnd: new Date("2025-02-01T00:00:00Z"),
+      totalCreditsConsumed: 5,
+      breakdown: [{ module: "prepare", sessionCount: 1, creditsConsumed: 5 }],
+      recentLedger: [],
+      recentUsageEvents: [],
+    });
+
+    const res = await request(app).get("/api/company/credits/me");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.creditBalance).toBe(15);
+    expect(creditServiceMocks.getUserSummary).toHaveBeenCalledWith("user-credits");
+  });
+
+  it("provisions a paid user and initializes credits", async () => {
+    const app = await createApp();
+
+    storageMocks.getUserByEmail.mockResolvedValueOnce(null);
+    storageMocks.upsertUser.mockResolvedValueOnce({
+      id: "user-new",
+      email: "new@example.com",
+      firstName: "New",
+      lastName: "User",
+      role: "admin",
+    });
+    storageMocks.getOrganization.mockResolvedValueOnce({
+      id: "org-1",
+      name: "Acme",
+      type: "customer",
+    });
+    storageMocks.addOrganizationMembership.mockResolvedValueOnce({
+      id: "membership-1",
+      organizationId: "org-1",
+      userId: "user-new",
+      role: "admin",
+    });
+
+    creditServiceMocks.initializeUserAccount.mockResolvedValueOnce({} as any);
+    creditServiceMocks.getUserSummary.mockResolvedValueOnce({
+      userId: "user-new",
+      accountTier: "paid",
+      monthlyCreditAllocation: 100,
+      creditBalance: 100,
+      billingCycleStart: new Date("2025-01-01T00:00:00Z"),
+      billingCycleEnd: new Date("2025-02-01T00:00:00Z"),
+      totalCreditsConsumed: 0,
+      breakdown: [],
+      recentLedger: [],
+      recentUsageEvents: [],
+    });
+
+    const res = await request(app)
+      .post("/api/company/users")
+      .send({
+        email: "new@example.com",
+        firstName: "New",
+        lastName: "User",
+        password: "supersecure",
+        accountTier: "paid",
+        monthlyCredits: 100,
+        organizationId: "org-1",
+        organizationRole: "admin",
+      });
+
+    expect(res.status).toBe(201);
+    expect(storageMocks.upsertUser).toHaveBeenCalledWith(expect.objectContaining({
+      email: "new@example.com",
+      firstName: "New",
+      role: "admin",
+    }));
+    expect(creditServiceMocks.initializeUserAccount).toHaveBeenCalledWith("user-new", "paid", 100);
+    expect(storageMocks.addOrganizationMembership).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      userId: "user-new",
+      role: "admin",
+    });
+    expect(res.body.data.user.id).toBe("user-new");
+    expect(res.body.data.credits.accountTier).toBe("paid");
+  });
+
+  it("allows admins to adjust user credit settings", async () => {
+    const app = await createApp();
+
+    const summary = {
+      userId: "user-adjust",
+      accountTier: "paid",
+      monthlyCreditAllocation: 150,
+      creditBalance: 120,
+      billingCycleStart: new Date("2025-01-01T00:00:00Z"),
+      billingCycleEnd: new Date("2025-02-01T00:00:00Z"),
+      totalCreditsConsumed: 30,
+      breakdown: [{ module: "practice", sessionCount: 3, creditsConsumed: 30 }],
+      recentLedger: [],
+      recentUsageEvents: [],
+    };
+
+    creditServiceMocks.adminAdjustUserCredits.mockResolvedValueOnce(summary);
+
+    const res = await request(app)
+      .patch("/api/company/users/user-adjust/credits")
+      .send({ monthlyCredits: 150, creditBalance: 120, reason: "Contract update" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.monthlyCreditAllocation).toBe(150);
+    expect(creditServiceMocks.adminAdjustUserCredits).toHaveBeenCalledWith("user-adjust", {
+      monthlyCredits: 150,
+      creditBalance: 120,
+      reason: "Contract update",
+    });
+  });
+
+  it("rejects credit updates without any fields", async () => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .patch("/api/company/users/user-adjust/credits")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(creditServiceMocks.adminAdjustUserCredits).not.toHaveBeenCalled();
+  });
+
+  it("prevents non-admins from updating credits", async () => {
+    const app = await createApp({ role: "user", id: "non-admin" });
+
+    const res = await request(app)
+      .patch("/api/company/users/user-adjust/credits")
+      .send({ monthlyCredits: 50 });
+
+    expect(res.status).toBe(403);
+    expect(creditServiceMocks.adminAdjustUserCredits).not.toHaveBeenCalled();
+  });
+});

--- a/server/__tests__/credit-service.test.ts
+++ b/server/__tests__/credit-service.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageMocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  updateUserBillingCycle: vi.fn(),
+  adjustUserCredits: vi.fn(),
+  recordCreditLedger: vi.fn(),
+  recordUsageEvent: vi.fn(),
+  getUserUsageSummary: vi.fn(),
+  getRecentCreditLedger: vi.fn(),
+  getRecentUsageEvents: vi.fn(),
+}));
+
+vi.mock("../storage.js", () => ({
+  storage: storageMocks,
+}));
+
+describe("credit service", () => {
+  beforeEach(async () => {
+    Object.values(storageMocks).forEach(mockFn => mockFn.mockReset?.());
+    await vi.resetModules();
+  });
+
+  it("guards against concurrent credit deductions dropping balance below zero", async () => {
+    const { creditService, InsufficientCreditsError } = await import("../services/credit-service.js");
+
+    const cycleStart = new Date("2025-01-01T00:00:00Z");
+    const cycleEnd = new Date("2025-02-01T00:00:00Z");
+
+    storageMocks.getUser
+      .mockResolvedValueOnce({
+        id: "user-1",
+        accountTier: "paid",
+        creditBalance: 5,
+        monthlyCreditAllocation: 100,
+        billingCycleStart: cycleStart,
+        billingCycleEnd: cycleEnd,
+      })
+      .mockResolvedValueOnce({
+        id: "user-1",
+        accountTier: "paid",
+        creditBalance: 3,
+        monthlyCreditAllocation: 100,
+        billingCycleStart: cycleStart,
+        billingCycleEnd: cycleEnd,
+      });
+
+    storageMocks.adjustUserCredits.mockResolvedValueOnce(undefined);
+
+    let thrown: unknown;
+    try {
+      await creditService.consumeCredits("user-1", "practice", 5);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(InsufficientCreditsError);
+    expect(storageMocks.adjustUserCredits).toHaveBeenCalledWith("user-1", -5, { preventNegative: true });
+    expect(storageMocks.recordCreditLedger).not.toHaveBeenCalled();
+    expect(storageMocks.recordUsageEvent).not.toHaveBeenCalled();
+
+    if (thrown instanceof InsufficientCreditsError) {
+      expect(thrown.required).toBe(5);
+      expect(thrown.available).toBe(3);
+    }
+  });
+});

--- a/server/__tests__/practice.routes.test.ts
+++ b/server/__tests__/practice.routes.test.ts
@@ -18,6 +18,14 @@ const storageMocks = vi.hoisted(() => ({
 
 const questionGeneratorMock = vi.hoisted(() => ({ generateQuestion: vi.fn() }));
 const evaluationServiceMock = vi.hoisted(() => ({ evaluateSessionResponses: vi.fn() }));
+const creditServiceMock = vi.hoisted(() => ({ consumeCredits: vi.fn() }));
+const InsufficientCreditsErrorMock = vi.hoisted(() =>
+  class InsufficientCreditsError extends Error {
+    constructor(public required: number, public available: number) {
+      super("Insufficient credits");
+    }
+  }
+);
 
 vi.mock("../storage.js", () => ({
   storage: storageMocks,
@@ -31,11 +39,18 @@ vi.mock("../services/response-evaluation-service.js", () => ({
   ResponseEvaluationService: vi.fn(() => evaluationServiceMock),
 }));
 
+vi.mock("../services/credit-service.js", () => ({
+  creditService: creditServiceMock,
+  InsufficientCreditsError: InsufficientCreditsErrorMock,
+}));
+
 describe("practice routes", () => {
   beforeEach(async () => {
     Object.values(storageMocks).forEach(mockFn => mockFn.mockReset?.());
     questionGeneratorMock.generateQuestion.mockReset();
     evaluationServiceMock.evaluateSessionResponses.mockReset();
+    creditServiceMock.consumeCredits.mockReset();
+    creditServiceMock.consumeCredits.mockResolvedValue({});
     await vi.resetModules();
   });
 
@@ -74,6 +89,39 @@ describe("practice routes", () => {
       scenarioId: "scenario-a",
       status: "active",
     }));
+    expect(creditServiceMock.consumeCredits).toHaveBeenCalledWith(
+      "user-456",
+      "practice",
+      10,
+      "practice-session-1",
+    );
+  });
+
+  it("fails gracefully when credits are insufficient", async () => {
+    const app = await createApp();
+
+    storageMocks.createPracticeSession.mockResolvedValueOnce({
+      id: "practice-session-credits",
+      scenarioId: "scenario-a",
+      status: "active",
+    });
+
+    const creditError = new InsufficientCreditsErrorMock(10, 2);
+    creditServiceMock.consumeCredits.mockRejectedValueOnce(creditError);
+
+    storageMocks.deletePracticeSession.mockResolvedValueOnce();
+
+    const res = await request(app)
+      .post("/api/practice/sessions")
+      .send({
+        scenarioId: "scenario-a",
+        interviewStage: "phone-screening",
+        difficultyLevel: "beginner",
+      });
+
+    expect(res.status).toBe(402);
+    expect(res.body.error).toBe("INSUFFICIENT_CREDITS");
+    expect(storageMocks.deletePracticeSession).toHaveBeenCalledWith("practice-session-credits");
   });
 
   it("generates an AI question, saves it, and advances the session", async () => {

--- a/server/__tests__/prepare-ai.routes.test.ts
+++ b/server/__tests__/prepare-ai.routes.test.ts
@@ -14,6 +14,15 @@ const mocks = vi.hoisted(() => ({
   emitToSession: vi.fn(),
 }));
 
+const creditServiceMock = vi.hoisted(() => ({ consumeCredits: vi.fn() }));
+const InsufficientCreditsErrorMock = vi.hoisted(() =>
+  class InsufficientCreditsError extends Error {
+    constructor(public required: number, public available: number) {
+      super("Insufficient credits");
+    }
+  }
+);
+
 vi.mock("../services/prepare-ai-service.js", () => ({
   PrepareAIService: vi.fn(() => ({
     createSession: mocks.createSession,
@@ -31,9 +40,16 @@ vi.mock("../services/realtime-gateway.js", () => ({
   emitToSession: mocks.emitToSession,
 }));
 
+vi.mock("../services/credit-service.js", () => ({
+  creditService: creditServiceMock,
+  InsufficientCreditsError: InsufficientCreditsErrorMock,
+}));
+
 describe("prepare-ai routes", () => {
   beforeEach(async () => {
     Object.values(mocks).forEach(mockFn => mockFn.mockReset?.());
+    creditServiceMock.consumeCredits.mockReset();
+    creditServiceMock.consumeCredits.mockResolvedValue({});
     await vi.resetModules();
   });
 
@@ -69,6 +85,32 @@ describe("prepare-ai routes", () => {
       interviewStage: "functional-team",
       experienceLevel: "senior",
     }));
+    expect(creditServiceMock.consumeCredits).toHaveBeenCalledWith(
+      "user-123",
+      "prepare",
+      5,
+      "prepare-session-1",
+    );
+  });
+
+  it("responds with 402 when credits are insufficient", async () => {
+    const app = await createApp();
+
+    mocks.createSession.mockResolvedValueOnce({ id: "prepare-session-low", jobPosition: "Engineer" });
+    creditServiceMock.consumeCredits.mockRejectedValueOnce(new InsufficientCreditsErrorMock(5, 1));
+    mocks.deleteSession.mockResolvedValueOnce();
+
+    const res = await request(app)
+      .post("/api/prepare-ai/sessions")
+      .send({
+        jobPosition: "Engineer",
+        interviewStage: "functional-team",
+        experienceLevel: "senior",
+      });
+
+    expect(res.status).toBe(402);
+    expect(res.body.error).toBe("INSUFFICIENT_CREDITS");
+    expect(mocks.deleteSession).toHaveBeenCalledWith("prepare-session-low");
   });
 
   it("generates the next AI question and emits it to the session room", async () => {

--- a/server/auth-simple.ts
+++ b/server/auth-simple.ts
@@ -4,6 +4,7 @@ import crypto from "crypto";
 import type { Express, RequestHandler } from "express";
 import { createSessionStore } from "./session-store";
 import { storage } from "./storage";
+import { creditService } from "./services/credit-service.js";
 
 export function getSession() {
   const sessionTtlMs = 7 * 24 * 60 * 60 * 1000; // 1 week
@@ -73,6 +74,13 @@ export async function setupSimpleAuth(app: Express) {
         role: "user",
         passwordHash: hashedPassword
       });
+
+      try {
+        await creditService.initializeUserAccount(user.id, "free");
+      } catch (error) {
+        console.error("Signup credit initialization error:", error);
+        return res.status(500).json({ message: "Registration failed - unable to initialize credits" });
+      }
 
       // Create session
       (req.session as any).userId = user.id;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,6 +26,7 @@ import { errorLogger, logAPIError } from "./services/error-logger";
 // import { coachingEngineService } from "./services/coaching-engine-service"; // QUARANTINED
 import { prepareAIRouter } from "./routes/prepare-ai";
 import practiceRouter from "./routes/practice";
+import companyDashboardRouter from "./routes/company-dashboard";
 import voiceServicesRouter from "./routes/voice-services-mvp";
 import testEndpoints from "./test-endpoints";
 
@@ -1828,6 +1829,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   app.use('/api/prepare-ai', requireAuthWithBypass, prepareAIRouter);
   app.use('/api/practice', requireAuthWithBypass, practiceRouter);
+  app.use('/api/company', requireAuthWithBypass, companyDashboardRouter);
   
   // Voice services routes
   app.use('/api/voice-services', voiceServicesRouter);

--- a/server/routes/company-dashboard.ts
+++ b/server/routes/company-dashboard.ts
@@ -1,0 +1,349 @@
+import { Router } from "express";
+import bcrypt from "bcryptjs";
+import crypto from "crypto";
+import { z } from "zod";
+import { storage } from "../storage.js";
+import { creditService } from "../services/credit-service.js";
+import { requireAdmin } from "../middleware/auth-middleware";
+
+const router = Router();
+
+const createOrganizationSchema = z.object({
+  name: z.string().min(1, "Organization name is required"),
+  type: z.enum(["customer", "reseller"]).default("customer"),
+});
+
+const provisionUserSchema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  lastName: z.string().optional(),
+  password: z.string().min(8),
+  accountTier: z.enum(["free", "paid"]).default("paid"),
+  monthlyCredits: z.number().min(0).optional(),
+  organizationId: z.string().uuid().optional(),
+  organizationRole: z.enum(["member", "manager", "admin"]).default("member"),
+});
+
+const addMemberSchema = z.object({
+  userId: z.string().min(1),
+  role: z.enum(["member", "manager", "admin"]).default("member"),
+  monthlyCredits: z.number().min(0).optional(),
+});
+
+const updateUserCreditsSchema = z.object({
+  accountTier: z.enum(["free", "paid"]).optional(),
+  monthlyCredits: z.number().min(0).optional(),
+  creditBalance: z.number().min(0).optional(),
+  reason: z.string().min(1).max(500).optional(),
+}).refine(
+  (payload) =>
+    typeof payload.accountTier !== "undefined"
+    || typeof payload.monthlyCredits !== "undefined"
+    || typeof payload.creditBalance !== "undefined",
+  {
+    message: "Provide at least one field to update",
+    path: ["accountTier"],
+  },
+);
+
+const MANAGER_ROLES = new Set(["owner", "admin", "manager"]);
+
+async function ensureOrganizationManagementAccess(userId: string, organizationId: string) {
+  const membership = await storage.getOrganizationMembership(userId, organizationId);
+  if (!membership || !MANAGER_ROLES.has(membership.role)) {
+    throw new Error("ACCESS_DENIED");
+  }
+  return membership;
+}
+
+router.post("/organizations", requireAdmin, async (req, res) => {
+  try {
+    const validation = createOrganizationSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "INVALID_ORGANIZATION",
+        details: validation.error.issues,
+      });
+    }
+
+    const organization = await storage.createOrganization({
+      ...validation.data,
+      createdBy: req.user!.id,
+    });
+
+    await storage.addOrganizationMembership({
+      organizationId: organization.id,
+      userId: req.user!.id,
+      role: "owner",
+    });
+
+    res.status(201).json({
+      success: true,
+      data: organization,
+    });
+  } catch (error) {
+    console.error("Failed to create organization:", error);
+    res.status(500).json({
+      error: "ORGANIZATION_CREATION_FAILED",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+router.post("/users", requireAdmin, async (req, res) => {
+  try {
+    const validation = provisionUserSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "INVALID_USER_PROVISION",
+        details: validation.error.issues,
+      });
+    }
+
+    const payload = validation.data;
+    const existingUser = await storage.getUserByEmail(payload.email);
+    const userId = existingUser?.id ?? crypto.randomUUID();
+    const role = payload.organizationRole === "admin"
+      ? "admin"
+      : payload.organizationRole === "manager"
+        ? "manager"
+        : existingUser?.role ?? "user";
+
+    const hashedPassword = await bcrypt.hash(payload.password, 12);
+
+    const user = await storage.upsertUser({
+      id: userId,
+      email: payload.email,
+      firstName: payload.firstName,
+      lastName: payload.lastName ?? "",
+      role,
+      passwordHash: hashedPassword,
+    });
+
+    await creditService.initializeUserAccount(
+      user.id,
+      payload.accountTier,
+      payload.monthlyCredits,
+    );
+
+    if (payload.organizationId) {
+      const organization = await storage.getOrganization(payload.organizationId);
+      if (!organization) {
+        return res.status(404).json({ error: "ORGANIZATION_NOT_FOUND" });
+      }
+
+      await storage.addOrganizationMembership({
+        organizationId: payload.organizationId,
+        userId: user.id,
+        role: payload.organizationRole,
+      });
+    }
+
+    const creditSummary = await creditService.getUserSummary(user.id);
+
+    res.status(201).json({
+      success: true,
+      data: {
+        user: {
+          id: user.id,
+          email: user.email,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          role: user.role,
+        },
+        credits: creditSummary,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to provision user:", error);
+    res.status(500).json({
+      error: "USER_PROVISION_FAILED",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+router.post("/organizations/:orgId/members", async (req, res) => {
+  try {
+    if (!req.user?.id) {
+      return res.status(401).json({ error: "UNAUTHORIZED" });
+    }
+
+    const validation = addMemberSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "INVALID_MEMBERSHIP",
+        details: validation.error.issues,
+      });
+    }
+
+    const { orgId } = req.params;
+    const payload = validation.data;
+
+    if (req.user.role !== "admin") {
+      const membership = await ensureOrganizationManagementAccess(req.user.id, orgId);
+      if (membership.role === "manager" && payload.role === "admin") {
+        return res.status(403).json({
+          error: "INSUFFICIENT_PRIVILEGES",
+          message: "Managers cannot assign admin memberships",
+        });
+      }
+    }
+
+    const member = await storage.addOrganizationMembership({
+      organizationId: orgId,
+      userId: payload.userId,
+      role: payload.role,
+    });
+
+    if (payload.role !== "member") {
+      const newRole = payload.role === "admin" ? "admin" : "manager";
+      await storage.updateUser(payload.userId, { role: newRole });
+    }
+
+    if (typeof payload.monthlyCredits === "number") {
+      await creditService.initializeUserAccount(payload.userId, payload.role === "member" ? "free" : "paid", payload.monthlyCredits);
+    }
+
+    res.status(201).json({
+      success: true,
+      data: member,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "ACCESS_DENIED") {
+      return res.status(403).json({
+        error: "ACCESS_DENIED",
+        message: "You do not have permission to manage this organization",
+      });
+    }
+
+    console.error("Failed to add organization member:", error);
+    res.status(500).json({
+      error: "MEMBERSHIP_UPDATE_FAILED",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+router.get("/credits/me", async (req, res) => {
+  try {
+    if (!req.user?.id) {
+      return res.status(401).json({ error: "UNAUTHORIZED" });
+    }
+
+    const summary = await creditService.getUserSummary(req.user.id);
+    res.json({ success: true, data: summary });
+  } catch (error) {
+    console.error("Failed to retrieve user credits:", error);
+    res.status(500).json({
+      error: "CREDIT_LOOKUP_FAILED",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+router.get("/users/:userId/credits", requireAdmin, async (req, res) => {
+  try {
+    const summary = await creditService.getUserSummary(req.params.userId);
+    res.json({ success: true, data: summary });
+  } catch (error) {
+    console.error("Failed to retrieve user credits:", error);
+    res.status(500).json({
+      error: "CREDIT_LOOKUP_FAILED",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+router.patch("/users/:userId/credits", requireAdmin, async (req, res) => {
+  try {
+    const validation = updateUserCreditsSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "INVALID_CREDIT_UPDATE",
+        details: validation.error.issues,
+      });
+    }
+
+    const summary = await creditService.adminAdjustUserCredits(
+      req.params.userId,
+      validation.data,
+    );
+
+    res.json({ success: true, data: summary });
+  } catch (error) {
+    console.error("Failed to update user credits:", error);
+    res.status(500).json({
+      error: "CREDIT_UPDATE_FAILED",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+router.get("/organizations/:orgId/usage", async (req, res) => {
+  try {
+    if (!req.user?.id) {
+      return res.status(401).json({ error: "UNAUTHORIZED" });
+    }
+
+    const { orgId } = req.params;
+
+    if (req.user.role !== "admin") {
+      await ensureOrganizationManagementAccess(req.user.id, orgId);
+    }
+
+    const organization = await storage.getOrganization(orgId);
+    if (!organization) {
+      return res.status(404).json({ error: "ORGANIZATION_NOT_FOUND" });
+    }
+
+    const members = await storage.getOrganizationMembers(orgId);
+    const usage = await Promise.all(
+      members.map(async (membership) => {
+        const summary = await creditService.getUserSummary(membership.userId);
+        return {
+          membership: {
+            id: membership.id,
+            role: membership.role,
+            userId: membership.userId,
+          },
+          user: {
+            id: membership.user.id,
+            email: membership.user.email,
+            firstName: membership.user.firstName,
+            lastName: membership.user.lastName,
+            role: membership.user.role,
+          },
+          credits: summary,
+        };
+      }),
+    );
+
+    res.json({
+      success: true,
+      data: {
+        organization: {
+          id: organization.id,
+          name: organization.name,
+          type: organization.type,
+        },
+        members: usage,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "ACCESS_DENIED") {
+      return res.status(403).json({
+        error: "ACCESS_DENIED",
+        message: "You do not have permission to view this organization",
+      });
+    }
+
+    console.error("Failed to retrieve organization usage:", error);
+    res.status(500).json({
+      error: "ORGANIZATION_USAGE_FAILED",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+export default router;

--- a/server/routes/practice.ts
+++ b/server/routes/practice.ts
@@ -11,10 +11,12 @@ import {
 } from "@shared/schema.js";
 import { AIQuestionGenerator } from "../services/ai-question-generator.js";
 import { ResponseEvaluationService } from "../services/response-evaluation-service.js";
+import { creditService, InsufficientCreditsError } from "../services/credit-service.js";
 
 const router = Router();
 const questionGenerator = new AIQuestionGenerator();
 const evaluationService = new ResponseEvaluationService();
+const PRACTICE_SESSION_CREDIT_COST = 10;
 
 // Validation schemas
 const createSessionSchema = z.object({
@@ -63,7 +65,31 @@ router.post('/sessions', async (req, res) => {
     };
 
     const session = await storage.createPracticeSession(sessionData);
-    
+
+    try {
+      await creditService.consumeCredits(
+        req.user.id,
+        'practice',
+        PRACTICE_SESSION_CREDIT_COST,
+        session.id,
+      );
+    } catch (error) {
+      await storage.deletePracticeSession(session.id).catch((deleteError) => {
+        console.error('Failed to rollback practice session after credit error:', deleteError);
+      });
+
+      if (error instanceof InsufficientCreditsError) {
+        return res.status(402).json({
+          error: 'INSUFFICIENT_CREDITS',
+          message: 'Not enough credits to start a Practice session',
+          required: error.required,
+          available: error.available,
+        });
+      }
+
+      throw error;
+    }
+
     res.status(201).json({
       success: true,
       data: session,
@@ -72,6 +98,14 @@ router.post('/sessions', async (req, res) => {
 
   } catch (error) {
     console.error('❌ Create practice session error:', error);
+    if (error instanceof InsufficientCreditsError) {
+      return res.status(402).json({
+        error: 'INSUFFICIENT_CREDITS',
+        message: 'Not enough credits to start a Practice session',
+        required: error.required,
+        available: error.available,
+      });
+    }
     res.status(500).json({
       error: 'Failed to create session',
       message: error instanceof Error ? error.message : 'Unknown error'

--- a/server/routes/prepare-ai.ts
+++ b/server/routes/prepare-ai.ts
@@ -5,9 +5,11 @@ import { Router } from "express";
 import { z } from "zod";
 import { PrepareAIService } from "../services/prepare-ai-service.js";
 import { emitToSession } from "../services/realtime-gateway.js";
+import { creditService, InsufficientCreditsError } from "../services/credit-service.js";
 
 const router = Router();
 const prepareAIService = new PrepareAIService();
+const PREPARE_SESSION_CREDIT_COST = 5;
 
 // Validation schemas
 const createSessionSchema = z.object({
@@ -54,7 +56,31 @@ router.post('/sessions', async (req, res) => {
     }
 
     const session = await prepareAIService.createSession(req.user.id, validation.data);
-    
+
+    try {
+      await creditService.consumeCredits(
+        req.user.id,
+        'prepare',
+        PREPARE_SESSION_CREDIT_COST,
+        session.id,
+      );
+    } catch (error) {
+      await prepareAIService.deleteSession(session.id).catch((deleteError) => {
+        console.error('Failed to rollback prepare session after credit error:', deleteError);
+      });
+
+      if (error instanceof InsufficientCreditsError) {
+        return res.status(402).json({
+          error: 'INSUFFICIENT_CREDITS',
+          message: 'Not enough credits to start a Prepare session',
+          required: error.required,
+          available: error.available,
+        });
+      }
+
+      throw error;
+    }
+
     res.status(201).json({
       success: true,
       data: session,
@@ -63,6 +89,14 @@ router.post('/sessions', async (req, res) => {
 
   } catch (error) {
     console.error('❌ Create AI session error:', error);
+    if (error instanceof InsufficientCreditsError) {
+      return res.status(402).json({
+        error: 'INSUFFICIENT_CREDITS',
+        message: 'Not enough credits to start a Prepare session',
+        required: error.required,
+        available: error.available,
+      });
+    }
     res.status(500).json({
       error: 'Failed to create session',
       message: error instanceof Error ? error.message : 'Unknown error'

--- a/server/services/credit-service.ts
+++ b/server/services/credit-service.ts
@@ -1,0 +1,275 @@
+import { storage } from "../storage.js";
+import {
+  type UpsertUser,
+  type User,
+} from "../../shared/schema.js";
+import type {
+  CreditLedgerSnapshot,
+  UsageEventSnapshot,
+  UserCreditSummary,
+} from "@shared/types";
+
+const DEFAULT_ALLOCATIONS: Record<string, number> = {
+  free: 20,
+  paid: 100,
+};
+
+export class InsufficientCreditsError extends Error {
+  constructor(public required: number, public available: number) {
+    super(`Insufficient credits: required ${required}, available ${available}`);
+    this.name = "InsufficientCreditsError";
+  }
+}
+
+class CreditService {
+  private addOneMonth(date: Date): Date {
+    const result = new Date(date.getTime());
+    result.setMonth(result.getMonth() + 1);
+    return result;
+  }
+
+  private resolveAllocation(tier?: string | null, override?: number): number {
+    if (typeof override === "number" && !Number.isNaN(override)) {
+      return override;
+    }
+
+    if (!tier) {
+      return DEFAULT_ALLOCATIONS.free;
+    }
+
+    const normalizedTier = tier.toLowerCase();
+    return DEFAULT_ALLOCATIONS[normalizedTier] ?? DEFAULT_ALLOCATIONS.free;
+  }
+
+  async initializeUserAccount(
+    userId: string,
+    tier: string,
+    monthlyCredits?: number,
+  ): Promise<User> {
+    const allocation = this.resolveAllocation(tier, monthlyCredits);
+    const start = new Date();
+    const end = this.addOneMonth(start);
+
+    const updatedUser = await storage.updateUserBillingCycle(userId, {
+      accountTier: tier,
+      monthlyCreditAllocation: allocation,
+      creditBalance: allocation,
+      billingCycleStart: start,
+      billingCycleEnd: end,
+    });
+
+    await storage.recordCreditLedger({
+      userId,
+      amount: allocation,
+      balanceAfter: updatedUser.creditBalance ?? allocation,
+      reason: "initial_allocation",
+      metadata: { tier },
+    });
+
+    return updatedUser;
+  }
+
+  private async ensureBillingCycle(user: User): Promise<User> {
+    const now = new Date();
+    const allocation = this.resolveAllocation(user.accountTier, user.monthlyCreditAllocation ?? undefined);
+
+    if (!user.billingCycleEnd || !user.billingCycleStart || now >= user.billingCycleEnd) {
+      const start = now;
+      const end = this.addOneMonth(start);
+
+      const updatedUser = await storage.updateUserBillingCycle(user.id, {
+        billingCycleStart: start,
+        billingCycleEnd: end,
+        monthlyCreditAllocation: allocation,
+        creditBalance: allocation,
+      });
+
+      await storage.recordCreditLedger({
+        userId: user.id,
+        amount: allocation,
+        balanceAfter: updatedUser.creditBalance ?? allocation,
+        reason: user.billingCycleEnd ? "cycle_reset" : "cycle_init",
+        metadata: { tier: updatedUser.accountTier },
+      });
+
+      return updatedUser;
+    }
+
+    return user;
+  }
+
+  async consumeCredits(
+    userId: string,
+    module: string,
+    amount: number,
+    sessionId?: string,
+  ): Promise<User> {
+    const user = await storage.getUser(userId);
+    if (!user) {
+      throw new Error(`User not found: ${userId}`);
+    }
+
+    const refreshedUser = await this.ensureBillingCycle(user);
+    const available = refreshedUser.creditBalance ?? 0;
+
+    if (available < amount) {
+      throw new InsufficientCreditsError(amount, available);
+    }
+
+    const updatedUser = await storage.adjustUserCredits(userId, -amount);
+
+    await storage.recordCreditLedger({
+      userId,
+      amount: -amount,
+      balanceAfter: updatedUser.creditBalance ?? available - amount,
+      reason: "session_start",
+      module,
+      sessionId,
+      metadata: { module, sessionId },
+    });
+
+    await storage.recordUsageEvent({
+      userId,
+      module,
+      sessionId,
+      creditsConsumed: amount,
+      metadata: { module, sessionId },
+    });
+
+    return updatedUser;
+  }
+
+  async getUserSummary(userId: string): Promise<UserCreditSummary> {
+    const user = await storage.getUser(userId);
+    if (!user) {
+      throw new Error(`User not found: ${userId}`);
+    }
+
+    const refreshedUser = await this.ensureBillingCycle(user);
+
+    const usageSummary = await storage.getUserUsageSummary(userId);
+    const recentLedgerRaw = await storage.getRecentCreditLedger(userId, 10);
+    const recentUsageRaw = await storage.getRecentUsageEvents(userId, 10);
+
+    const recentLedger: CreditLedgerSnapshot[] = recentLedgerRaw.map((entry) => ({
+      id: entry.id,
+      amount: entry.amount,
+      balanceAfter: entry.balanceAfter,
+      reason: entry.reason,
+      module: entry.module,
+      sessionId: entry.sessionId,
+      metadata: entry.metadata as Record<string, unknown> | null,
+      createdAt: entry.createdAt ?? new Date(),
+    }));
+
+    const recentUsageEvents: UsageEventSnapshot[] = recentUsageRaw.map((event) => ({
+      id: event.id,
+      module: event.module,
+      sessionId: event.sessionId,
+      creditsConsumed: event.creditsConsumed,
+      occurredAt: event.occurredAt ?? new Date(),
+      metadata: event.metadata as Record<string, unknown> | null,
+    }));
+
+    return {
+      userId,
+      accountTier: refreshedUser.accountTier ?? "free",
+      monthlyCreditAllocation: refreshedUser.monthlyCreditAllocation ?? this.resolveAllocation(refreshedUser.accountTier),
+      creditBalance: refreshedUser.creditBalance ?? 0,
+      billingCycleStart: refreshedUser.billingCycleStart ?? null,
+      billingCycleEnd: refreshedUser.billingCycleEnd ?? null,
+      totalCreditsConsumed: usageSummary.totalCreditsConsumed,
+      breakdown: usageSummary.breakdown,
+      recentLedger,
+      recentUsageEvents,
+    };
+  }
+
+  async adminAdjustUserCredits(
+    userId: string,
+    updates: {
+      accountTier?: string;
+      monthlyCredits?: number;
+      creditBalance?: number;
+      reason?: string;
+    },
+  ): Promise<UserCreditSummary> {
+    const user = await storage.getUser(userId);
+    if (!user) {
+      throw new Error(`User not found: ${userId}`);
+    }
+
+    const adminReason = updates.reason ?? null;
+    const patch: Partial<UpsertUser> = {};
+
+    const previousAllocation = user.monthlyCreditAllocation ?? this.resolveAllocation(user.accountTier);
+    const previousBalance = user.creditBalance ?? 0;
+
+    let effectiveTier = updates.accountTier ?? user.accountTier ?? "free";
+    let allocationChanged = false;
+    let newAllocationValue = previousAllocation;
+
+    if (updates.accountTier) {
+      patch.accountTier = updates.accountTier;
+      effectiveTier = updates.accountTier;
+      if (typeof updates.monthlyCredits === "undefined") {
+        allocationChanged = true;
+        newAllocationValue = this.resolveAllocation(effectiveTier);
+        patch.monthlyCreditAllocation = newAllocationValue;
+      }
+    }
+
+    if (typeof updates.monthlyCredits === "number" && !Number.isNaN(updates.monthlyCredits)) {
+      allocationChanged = true;
+      newAllocationValue = this.resolveAllocation(effectiveTier, updates.monthlyCredits);
+      patch.monthlyCreditAllocation = newAllocationValue;
+    }
+
+    let balanceChanged = false;
+    let newBalance = previousBalance;
+    if (typeof updates.creditBalance === "number" && !Number.isNaN(updates.creditBalance)) {
+      balanceChanged = true;
+      newBalance = updates.creditBalance;
+      patch.creditBalance = newBalance;
+    }
+
+    const updatedUser = Object.keys(patch).length > 0
+      ? await storage.updateUser(userId, patch)
+      : user;
+
+    if (allocationChanged && newAllocationValue !== previousAllocation) {
+      await storage.recordCreditLedger({
+        userId,
+        amount: 0,
+        balanceAfter: updatedUser.creditBalance ?? newBalance,
+        reason: "allocation_update",
+        metadata: {
+          previousAllocation,
+          newAllocation: newAllocationValue,
+          adminReason,
+        },
+      });
+    }
+
+    if (balanceChanged) {
+      const delta = newBalance - previousBalance;
+      if (delta !== 0) {
+        await storage.recordCreditLedger({
+          userId,
+          amount: delta,
+          balanceAfter: updatedUser.creditBalance ?? newBalance,
+          reason: "manual_adjustment",
+          metadata: {
+            previousBalance,
+            newBalance,
+            adminReason,
+          },
+        });
+      }
+    }
+
+    return this.getUserSummary(userId);
+  }
+}
+
+export const creditService = new CreditService();

--- a/server/services/credit-service.ts
+++ b/server/services/credit-service.ts
@@ -116,7 +116,15 @@ class CreditService {
       throw new InsufficientCreditsError(amount, available);
     }
 
-    const updatedUser = await storage.adjustUserCredits(userId, -amount);
+    const updatedUser = await storage.adjustUserCredits(userId, -amount, {
+      preventNegative: true,
+    });
+
+    if (!updatedUser) {
+      const latest = await storage.getUser(userId);
+      const latestBalance = latest?.creditBalance ?? 0;
+      throw new InsufficientCreditsError(amount, latestBalance);
+    }
 
     await storage.recordCreditLedger({
       userId,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,5 +1,9 @@
 import {
   users,
+  organizations,
+  organizationMemberships,
+  creditLedger,
+  usageEvents,
   interviewScenarios,
   interviewSessions,
   interviewMessages,
@@ -28,6 +32,14 @@ import {
   aiPrepareResponses,
   type User,
   type UpsertUser,
+  type InsertOrganization,
+  type Organization,
+  type InsertOrganizationMembership,
+  type OrganizationMembership,
+  type InsertCreditLedger,
+  type CreditLedgerEntry,
+  type InsertUsageEvent,
+  type UsageEvent,
   type InsertInterviewScenario,
   type InterviewScenario,
   type InsertInterviewSession,
@@ -85,12 +97,31 @@ import {
 } from "@shared/schema";
 import { db } from "./db";
 import { eq, desc, and, count, avg, sql, or } from "drizzle-orm";
+import { UserUsageSummary } from "@shared/types";
 
 export interface IStorage {
   // User operations
   getUser(id: string): Promise<User | undefined>;
   getUserByEmail(email: string): Promise<User | undefined>;
   upsertUser(user: UpsertUser): Promise<User>;
+  updateUser(userId: string, updates: Partial<UpsertUser>): Promise<User>;
+  updateUserBillingCycle(userId: string, updates: Partial<UpsertUser>): Promise<User>;
+  adjustUserCredits(userId: string, delta: number): Promise<User>;
+
+  // Organization operations
+  createOrganization(org: InsertOrganization): Promise<Organization>;
+  getOrganization(id: string): Promise<Organization | undefined>;
+  addOrganizationMembership(membership: InsertOrganizationMembership): Promise<OrganizationMembership>;
+  getOrganizationMembership(userId: string, organizationId: string): Promise<OrganizationMembership | undefined>;
+  getOrganizationMembers(organizationId: string): Promise<(OrganizationMembership & { user: User })[]>;
+  getUserMemberships(userId: string): Promise<OrganizationMembership[]>;
+
+  // Credits & usage
+  recordCreditLedger(entry: InsertCreditLedger): Promise<CreditLedgerEntry>;
+  getRecentCreditLedger(userId: string, limit?: number): Promise<CreditLedgerEntry[]>;
+  recordUsageEvent(event: InsertUsageEvent): Promise<UsageEvent>;
+  getRecentUsageEvents(userId: string, limit?: number): Promise<UsageEvent[]>;
+  getUserUsageSummary(userId: string): Promise<UserUsageSummary>;
 
   // Interview scenario operations
   getInterviewScenarios(stage?: string): Promise<InterviewScenarioWithStats[]>;
@@ -300,6 +331,173 @@ export class DatabaseStorage implements IStorage {
       })
       .returning();
     return user;
+  }
+
+  async updateUser(userId: string, updates: Partial<UpsertUser>): Promise<User> {
+    const [user] = await db
+      .update(users)
+      .set({
+        ...updates,
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId))
+      .returning();
+    return user;
+  }
+
+  async updateUserBillingCycle(userId: string, updates: Partial<UpsertUser>): Promise<User> {
+    return this.updateUser(userId, updates);
+  }
+
+  async adjustUserCredits(userId: string, delta: number): Promise<User> {
+    const [user] = await db
+      .update(users)
+      .set({
+        creditBalance: sql`${users.creditBalance} + ${delta}`,
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId))
+      .returning();
+    return user;
+  }
+
+  async createOrganization(org: InsertOrganization): Promise<Organization> {
+    const [organization] = await db
+      .insert(organizations)
+      .values(org)
+      .returning();
+    return organization;
+  }
+
+  async getOrganization(id: string): Promise<Organization | undefined> {
+    const [organization] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, id));
+    return organization;
+  }
+
+  async addOrganizationMembership(
+    membership: InsertOrganizationMembership,
+  ): Promise<OrganizationMembership> {
+    const [result] = await db
+      .insert(organizationMemberships)
+      .values(membership)
+      .onConflictDoUpdate({
+        target: [organizationMemberships.organizationId, organizationMemberships.userId],
+        set: {
+          role: membership.role,
+          createdAt: new Date(),
+        },
+      })
+      .returning();
+    return result;
+  }
+
+  async getOrganizationMembership(
+    userId: string,
+    organizationId: string,
+  ): Promise<OrganizationMembership | undefined> {
+    const [membership] = await db
+      .select()
+      .from(organizationMemberships)
+      .where(
+        and(
+          eq(organizationMemberships.userId, userId),
+          eq(organizationMemberships.organizationId, organizationId),
+        ),
+      );
+    return membership;
+  }
+
+  async getOrganizationMembers(
+    organizationId: string,
+  ): Promise<(OrganizationMembership & { user: User })[]> {
+    const memberships = await db.query.organizationMemberships.findMany({
+      where: eq(organizationMemberships.organizationId, organizationId),
+      with: {
+        user: true,
+      },
+      orderBy: [desc(organizationMemberships.createdAt)],
+    });
+
+    return memberships.map((membership) => ({
+      ...membership,
+      user: membership.user!,
+    }));
+  }
+
+  async getUserMemberships(userId: string): Promise<OrganizationMembership[]> {
+    const memberships = await db
+      .select()
+      .from(organizationMemberships)
+      .where(eq(organizationMemberships.userId, userId));
+    return memberships;
+  }
+
+  async recordCreditLedger(entry: InsertCreditLedger): Promise<CreditLedgerEntry> {
+    const [ledgerEntry] = await db
+      .insert(creditLedger)
+      .values(entry)
+      .returning();
+    return ledgerEntry;
+  }
+
+  async getRecentCreditLedger(
+    userId: string,
+    limit: number = 10,
+  ): Promise<CreditLedgerEntry[]> {
+    return db
+      .select()
+      .from(creditLedger)
+      .where(eq(creditLedger.userId, userId))
+      .orderBy(desc(creditLedger.createdAt))
+      .limit(limit);
+  }
+
+  async recordUsageEvent(event: InsertUsageEvent): Promise<UsageEvent> {
+    const [usageEvent] = await db
+      .insert(usageEvents)
+      .values(event)
+      .returning();
+    return usageEvent;
+  }
+
+  async getRecentUsageEvents(
+    userId: string,
+    limit: number = 10,
+  ): Promise<UsageEvent[]> {
+    return db
+      .select()
+      .from(usageEvents)
+      .where(eq(usageEvents.userId, userId))
+      .orderBy(desc(usageEvents.occurredAt))
+      .limit(limit);
+  }
+
+  async getUserUsageSummary(userId: string): Promise<UserUsageSummary> {
+    const rows = await db
+      .select({
+        module: usageEvents.module,
+        sessionCount: count(usageEvents.id),
+        creditsConsumed: sql<number>`COALESCE(SUM(${usageEvents.creditsConsumed}), 0)` ,
+      })
+      .from(usageEvents)
+      .where(eq(usageEvents.userId, userId))
+      .groupBy(usageEvents.module);
+
+    const breakdown = rows.map((row) => ({
+      module: row.module,
+      sessionCount: Number(row.sessionCount),
+      creditsConsumed: Number(row.creditsConsumed),
+    }));
+
+    const totalCreditsConsumed = breakdown.reduce((acc, item) => acc + item.creditsConsumed, 0);
+
+    return {
+      totalCreditsConsumed,
+      breakdown,
+    };
   }
 
   // Interview scenario operations

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -106,7 +106,11 @@ export interface IStorage {
   upsertUser(user: UpsertUser): Promise<User>;
   updateUser(userId: string, updates: Partial<UpsertUser>): Promise<User>;
   updateUserBillingCycle(userId: string, updates: Partial<UpsertUser>): Promise<User>;
-  adjustUserCredits(userId: string, delta: number): Promise<User>;
+  adjustUserCredits(
+    userId: string,
+    delta: number,
+    options?: { preventNegative?: boolean },
+  ): Promise<User | undefined>;
 
   // Organization operations
   createOrganization(org: InsertOrganization): Promise<Organization>;
@@ -349,15 +353,31 @@ export class DatabaseStorage implements IStorage {
     return this.updateUser(userId, updates);
   }
 
-  async adjustUserCredits(userId: string, delta: number): Promise<User> {
+  async adjustUserCredits(
+    userId: string,
+    delta: number,
+    options?: { preventNegative?: boolean },
+  ): Promise<User | undefined> {
+    const preventNegative = options?.preventNegative ?? false;
+    const now = new Date();
+
+    const whereClause = preventNegative && delta < 0
+      ? and(eq(users.id, userId), sql`COALESCE(${users.creditBalance}, 0) >= ${-delta}`)
+      : eq(users.id, userId);
+
     const [user] = await db
       .update(users)
       .set({
-        creditBalance: sql`${users.creditBalance} + ${delta}`,
-        updatedAt: new Date(),
+        creditBalance: sql`COALESCE(${users.creditBalance}, 0) + ${delta}`,
+        updatedAt: now,
       })
-      .where(eq(users.id, userId))
+      .where(whereClause)
       .returning();
+
+    if (!user && preventNegative && delta < 0) {
+      return undefined;
+    }
+
     return user;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -10,6 +10,7 @@ import {
   index,
   uuid,
   numeric,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -47,9 +48,66 @@ export const users = pgTable("users", {
   lastName: varchar("last_name"),
   profileImageUrl: varchar("profile_image_url"),
   passwordHash: varchar("password_hash"), // For secure password authentication
-  role: varchar("role").default("user"), // user, admin
+  role: varchar("role").default("user"), // user, admin, manager
+  accountTier: varchar("account_tier", { length: 50 }).default("free"),
+  monthlyCreditAllocation: integer("monthly_credit_allocation").default(20),
+  creditBalance: integer("credit_balance").default(20),
+  billingCycleStart: timestamp("billing_cycle_start"),
+  billingCycleEnd: timestamp("billing_cycle_end"),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
+});
+
+export const organizations = pgTable("organizations", {
+  id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+  name: varchar("name", { length: 255 }).notNull(),
+  type: varchar("type", { length: 50 }).default("customer"),
+  createdBy: varchar("created_by").references(() => users.id),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
+export const organizationMemberships = pgTable(
+  "organization_memberships",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    userId: varchar("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: varchar("role", { length: 50 }).default("member"),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("organization_memberships_org_user_idx").on(
+      table.organizationId,
+      table.userId,
+    ),
+  ],
+);
+
+export const creditLedger = pgTable("credit_ledger", {
+  id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  amount: integer("amount").notNull(),
+  balanceAfter: integer("balance_after"),
+  reason: varchar("reason", { length: 100 }).notNull(),
+  module: varchar("module", { length: 50 }),
+  sessionId: varchar("session_id"),
+  metadata: jsonb("metadata"),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const usageEvents = pgTable("usage_events", {
+  id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  module: varchar("module", { length: 50 }).notNull(),
+  sessionId: varchar("session_id"),
+  creditsConsumed: integer("credits_consumed").notNull(),
+  metadata: jsonb("metadata"),
+  occurredAt: timestamp("occurred_at").defaultNow(),
 });
 
 // Interview scenarios table
@@ -307,6 +365,17 @@ export const usersRelations = relations(users, ({ many }) => ({
   interviewSessions: many(interviewSessions),
 }));
 
+export const organizationMembershipsRelations = relations(organizationMemberships, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [organizationMemberships.organizationId],
+    references: [organizations.id],
+  }),
+  user: one(users, {
+    fields: [organizationMemberships.userId],
+    references: [users.id],
+  }),
+}));
+
 export const interviewScenariosRelations = relations(interviewScenarios, ({ one, many }) => ({
   createdBy: one(users, {
     fields: [interviewScenarios.createdBy],
@@ -351,6 +420,32 @@ export const insertUserSchema = createInsertSchema(users).pick({
   profileImageUrl: true,
   passwordHash: true,
   role: true,
+  accountTier: true,
+  monthlyCreditAllocation: true,
+  creditBalance: true,
+  billingCycleStart: true,
+  billingCycleEnd: true,
+});
+
+export const insertOrganizationSchema = createInsertSchema(organizations).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const insertOrganizationMembershipSchema = createInsertSchema(organizationMemberships).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const insertCreditLedgerSchema = createInsertSchema(creditLedger).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const insertUsageEventSchema = createInsertSchema(usageEvents).omit({
+  id: true,
+  occurredAt: true,
 });
 
 export const insertInterviewScenarioSchema = createInsertSchema(interviewScenarios).omit({
@@ -381,6 +476,14 @@ export const insertAiEvaluationResultSchema = createInsertSchema(aiEvaluationRes
 // Types
 export type UpsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
+export type InsertOrganization = z.infer<typeof insertOrganizationSchema>;
+export type Organization = typeof organizations.$inferSelect;
+export type InsertOrganizationMembership = z.infer<typeof insertOrganizationMembershipSchema>;
+export type OrganizationMembership = typeof organizationMemberships.$inferSelect;
+export type InsertCreditLedger = z.infer<typeof insertCreditLedgerSchema>;
+export type CreditLedgerEntry = typeof creditLedger.$inferSelect;
+export type InsertUsageEvent = z.infer<typeof insertUsageEventSchema>;
+export type UsageEvent = typeof usageEvents.$inferSelect;
 export type InsertInterviewScenario = z.infer<typeof insertInterviewScenarioSchema>;
 export type InterviewScenario = typeof interviewScenarios.$inferSelect;
 export type InsertInterviewSession = z.infer<typeof insertInterviewSessionSchema>;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -23,6 +23,48 @@ export interface AIResponse {
   feedback?: string;
 }
 
+export interface UsageBreakdownEntry {
+  module: string;
+  sessionCount: number;
+  creditsConsumed: number;
+}
+
+export interface UserUsageSummary {
+  totalCreditsConsumed: number;
+  breakdown: UsageBreakdownEntry[];
+}
+
+export interface CreditLedgerSnapshot {
+  id: string;
+  amount: number;
+  balanceAfter: number | null;
+  reason: string;
+  module?: string | null;
+  sessionId?: string | null;
+  metadata?: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+export interface UsageEventSnapshot {
+  id: string;
+  module: string;
+  sessionId?: string | null;
+  creditsConsumed: number;
+  occurredAt: Date;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface UserCreditSummary extends UserUsageSummary {
+  userId: string;
+  accountTier: string;
+  monthlyCreditAllocation: number;
+  creditBalance: number;
+  billingCycleStart: Date | null;
+  billingCycleEnd: Date | null;
+  recentLedger: CreditLedgerSnapshot[];
+  recentUsageEvents: UsageEventSnapshot[];
+}
+
 export interface STARAssessment {
   situation: number;
   task: number;


### PR DESCRIPTION
## Summary
- add a protected company dashboard route that surfaces credit balances, usage history, and admin quick actions for company roles
- expose a company navigation entry and landing card so admins/managers can reach the dashboard from the standard login flow
- document the provisioning and credit adjustment endpoints within the dashboard to clarify how administrators manage accounts

## Testing
- `npm run check` *(fails: missing vite/client type definitions in this container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dce8ce2e94832b8712c3c2c60b4da6